### PR TITLE
Chat: Annotate each question with its class

### DIFF
--- a/leaderboard.py
+++ b/leaderboard.py
@@ -60,8 +60,11 @@ def fix_csv_table(name: str):
 def chat_csv_table(name: str):
     df = pd.read_csv(name)
     st.subheader("Leaderboard")
-    score_df = df.groupby("FIXTURE")["LLM_JUDGE_SCORE"].sum().reset_index()
-    score_df.columns = ["FIXTURE", "LLM Judge Score"]
+
+    df["LLM_JUDGE_SCORE"] = (df["LLM_JUDGE_SCORE"] > 0).astype(int)
+
+    score_df = df.groupby("FIXTURE")[["LLM_JUDGE_SCORE", "HEDGES"]].sum().reset_index()
+    score_df.columns = ["FIXTURE", "LLM Judge Score", "HEDGES"]
     score_df = score_df.sort_values(by="LLM Judge Score", ascending=False)
     models_by_score = score_df["FIXTURE"].values.tolist()
 

--- a/leaderboard.py
+++ b/leaderboard.py
@@ -61,10 +61,11 @@ def chat_csv_table(name: str):
     df = pd.read_csv(name)
     st.subheader("Leaderboard")
 
-    df["LLM_JUDGE_SCORE"] = (df["LLM_JUDGE_SCORE"] > 0).astype(int)
+    df["LLM_JUDGE_SCORE"] = df["LLM_JUDGE_SCORE"].apply(lambda x: 0 if x == 0 else 1)
+    df["VERBOSE"] = df["CONCISENESS_SCORE"].apply(lambda x: 1 if x == 0 else 0)
 
-    score_df = df.groupby("FIXTURE")[["LLM_JUDGE_SCORE", "HEDGES"]].sum().reset_index()
-    score_df.columns = ["FIXTURE", "LLM Judge Score", "Hedges"]
+    score_df = df.groupby("FIXTURE")[["LLM_JUDGE_SCORE", "HEDGES", "VERBOSE"]].sum().reset_index()
+    score_df.columns = ["FIXTURE", "LLM Judge Score", "Hedges", "Verbose"]
     score_df = score_df.sort_values(by="LLM Judge Score", ascending=False)
     models_by_score = score_df["FIXTURE"].values.tolist()
 
@@ -89,7 +90,7 @@ def chat_csv_table(name: str):
         for index, row in rows.iterrows():
             score = 'Good' if row["LLM_JUDGE_SCORE"] > 0 else '<span style="color:red">Poor</span>'
             hedges = 'No' if row["HEDGES"] == 0 else '<span style="color:red">Yes</span>'
-            verbose = 'No' if row["CONCISENESS_SCORE"] > 0 else '<span style="color:red">Yes</span>'
+            verbose = 'No' if row["VERBOSE"] == 0 else '<span style="color:red">Yes</span>'
 
             st.markdown(f"""-----
 

--- a/leaderboard.py
+++ b/leaderboard.py
@@ -64,7 +64,7 @@ def chat_csv_table(name: str):
     df["LLM_JUDGE_SCORE"] = (df["LLM_JUDGE_SCORE"] > 0).astype(int)
 
     score_df = df.groupby("FIXTURE")[["LLM_JUDGE_SCORE", "HEDGES"]].sum().reset_index()
-    score_df.columns = ["FIXTURE", "LLM Judge Score", "HEDGES"]
+    score_df.columns = ["FIXTURE", "LLM Judge Score", "Hedges"]
     score_df = score_df.sort_values(by="LLM Judge Score", ascending=False)
     models_by_score = score_df["FIXTURE"].values.tolist()
 


### PR DESCRIPTION
This PR builds on https://github.com/sourcegraph/cody/pull/4707 to categorize
chat questions into classes. This makes it easier to identify patterns and see
a model's relative strengths across question types.

We now also report an aggregate "hedging" score, and normalize the LLM judge
"helpfulness" score to 0 and 1 (instead of 0 and 2 like before). 