### PR TITLE
Make display consistent across use cases

### DIFF
--- a/leaderboard.py
+++ b/leaderboard.py
@@ -58,9 +58,7 @@ Average score across all **{num_questions} questions**. Scores of 1 are 'good', 
 
 🤖 **LLM Judge Score**: {score} | 🤔 **Confident**: {confident} | 🕑 **Concise**: {concise}
 
-**Question**: {row["CHAT_QUESTION"]}
-
-**Question Class**: {row["QUESTION_CLASS"]}
+**Question**: {row["CHAT_QUESTION"]} | **Question Class**: {row["QUESTION_CLASS"]}
 
 **Response**: {row["CHAT_REPLY"]}
 

--- a/leaderboard.py
+++ b/leaderboard.py
@@ -23,8 +23,8 @@ def chat_csv_table(name: str):
     st.markdown(f'''
 Average score across all **{num_questions} questions**. Scores of 1 are 'good', meaning averages closer to 1.0 are better.
 * LLM judge score: whether an LLM judge deemed the response to be helpful and informative.
-* Confident: whether the model responds affirmatively, without excessive hedging like apologizing.
-* Concise: whether the model responds succinctly, instead of repeating itself or adding extra content.''')
+* Confident: whether the model responds affirmatively, without excessive hedging like apologizing. Hedging is detected via regex.
+* Concise: whether an LLM judge deemed the response succinct, without repetitions or extra content.''')
 
     pivot_df = df.pivot(index=["CHAT_QUESTION", "QUESTION_CLASS"],
                         columns="FIXTURE", values="LLM_JUDGE_SCORE")


### PR DESCRIPTION
This PR makes the content and style consistent across Chat, Fix, and Unit Test:
* Use subheaders to split summary, score table, and model responses
* Color poor responses in red to draw attention
* Use positive metrics everywhere, so larger scores always mean 'better'

It also documents what the scores and metrics mean.